### PR TITLE
Fix dispatch test call

### DIFF
--- a/api/campaign.js
+++ b/api/campaign.js
@@ -4,7 +4,6 @@ const { wrap } = require('./middleware')
 const { BadRequestError, NotFoundError } = require("./middleware/errors")
 const { plivo_api } = require('./plivo')
 const { callerCallParams } = require('../dialer')
-const host = process.env.BASE_URL
 
 //index
 app.get('/api/campaigns', wrap(async (req, res, next) => {
@@ -82,7 +81,7 @@ app.post('/api/campaigns/:id/assessment', wrap(async (req, res, next) => {
   if (!campaign) return next(new NotFoundError('No Campaign Exists With ID: ' + req.params.id))
   if (!req.body.data.mobile_number) return next(new BadRequestError('No Phone Number'))
   const mobile = process.env.COUNTRY_ISO == 'AU' ? req.body.data.mobile_number.replace(/^0/, '61'): req.body.data.mobile_number
-  await plivo_api('make_call', callerCallParams(campaign, mobile, host, 1))
+  await plivo_api('make_call', callerCallParams(campaign, mobile, 1))
   return res.json({data: req.params.id})
 }))
 
@@ -92,7 +91,7 @@ app.post('/api/campaigns/:id/outbound_caller', wrap(async (req, res, next) => {
   if (!campaign) return next(new NotFoundError('No Campaign Exists With ID: ' + req.params.id))
   if (!req.body.data.mobile_number) return next(new BadRequestError('No Phone Number'))
   const mobile = process.env.COUNTRY_ISO == 'AU' ? req.body.data.mobile_number.replace(/^0/, '61'): req.body.data.mobile_number
-  await plivo_api('make_call', callerCallParams(campaign, mobile, host, 0))
+  await plivo_api('make_call', callerCallParams(campaign, mobile, 0))
   return res.json({data: req.params.id})
 }))
 

--- a/api/plivo.js
+++ b/api/plivo.js
@@ -2,6 +2,11 @@ const plivo = require('plivo')
 const promisify = require('es6-promisify')
 const api = plivo.RestAPI({ authId: process.env.PLIVO_API_ID || 'test', authToken: process.env.PLIVO_API_TOKEN || 'test'})
 
+let callback_base_url = process.env.PLIVO_CALLBACK_BASE_URL || process.env.BASE_URL
+
+module.exports.get_callback_base_url = () => { return callback_base_url }
+module.exports.set_callback_base_url = (url) => { callback_base_url = url }
+
 module.exports.plivo_signature = api.middleware({host: process.env.BASE_URL})
 
 module.exports.plivo_api = (endpoint, params, options) => {

--- a/campaigns/plivo_setup.js
+++ b/campaigns/plivo_setup.js
@@ -1,4 +1,4 @@
-const { plivo_api } = require('../api/plivo')
+const { get_callback_base_url, plivo_api } = require('../api/plivo')
 const _ = require('lodash')
 const { Campaign } = require('../models')
 const { NoNumbersError } = require('../api/middleware/errors')
@@ -23,12 +23,12 @@ const setup_inbound = async (campaign) => {
 }
 
 const setup_inbound_infrastructure = async (campaign) => {
-  const base_url = process.env.BASE_URL || 'https://test'
+  const callback_url = get_callback_base_url()
   const payload = {
     app_name: `kooragang-${process.env.NODE_ENV || 'development'}-${campaign.id}-${campaign.name.replace(/\W/g, '_').toLowerCase()}_${moment().format('YYMMDDHHmm')}`,
-    answer_url: `${base_url}/connect?campaign_id=${campaign.id}`,
-    fallback_answer_url: `${base_url}/log?event=fallback&campaign_id=${campaign.id}`,
-    hangup_url: `${base_url}/call_ended?campaign_id=${campaign.id}`
+    answer_url: `${callback_url}/connect?campaign_id=${campaign.id}`,
+    fallback_answer_url: `${callback_url}/log?event=fallback&campaign_id=${campaign.id}`,
+    hangup_url: `${callback_url}/call_ended?campaign_id=${campaign.id}`
   }
   try {
     const inbound_number = await create_app_and_link_number(payload, campaign.number_region)

--- a/ivr/callee.js
+++ b/ivr/callee.js
@@ -44,7 +44,7 @@ app.post('/answer', async ({body, query}, res) => {
         conference_id: `conference-${caller.id}`,
         member_id: caller.conference_member_id,
         text: name,
-        callback_url: res.locals.appUrl(`log?event=speak_name`)
+        callback_url: res.locals.plivoCallbackUrl(`log?event=speak_name`)
       }, voice())
       try{
         if (process.env.SPEAK_NAMES) await plivo_api('speak_conference_member', params)
@@ -58,7 +58,7 @@ app.post('/answer', async ({body, query}, res) => {
       startConferenceOnEnter: false,
       stayAlone: false,
       endConferenceOnExit: true,
-      callbackUrl: res.locals.appUrl(`conference_event/callee?caller_id=${caller.id}&campaign_id=${query.campaign_id}`)
+      callbackUrl: res.locals.plivoCallbackUrl(`conference_event/callee?caller_id=${caller.id}&campaign_id=${query.campaign_id}`)
     })
   } else {
     const call = await Call.query().insert({

--- a/ivr/caller_assessment.js
+++ b/ivr/caller_assessment.js
@@ -11,7 +11,7 @@ app.post('/survey_assessment', async ({query}, res) => {
   const caller_id = query.caller_id
   const questionData = questions[question]
   const surveyResponse = r.addGetDigits({
-    action: res.locals.appUrl(`survey_result_assessment?q=${question}&caller_id=${caller_id}&campaign_id=${query.campaign_id}&assessment=1`),
+    action: res.locals.plivoCallbackUrl(`survey_result_assessment?q=${question}&caller_id=${caller_id}&campaign_id=${query.campaign_id}&assessment=1`),
     redirect: true,
     retries: 10,
     numDigits: 1,
@@ -35,10 +35,10 @@ app.post('/survey_result_assessment', async ({query, body}, res) => {
 
   if (multiple && (body.Digits  === '*' || query.digit  === '*')) {
     if (question.next) {
-      r.addRedirect(res.locals.appUrl(`survey_assessment?q=${question.next}&caller_id=${query.caller_id}&campaign_id=${query.campaign_id}&assessment=1`))
+      r.addRedirect(res.locals.plivoCallbackUrl(`survey_assessment?q=${question.next}&caller_id=${query.caller_id}&campaign_id=${query.campaign_id}&assessment=1`))
     } else {
       r.addSpeakI18n('end_assessment_survey')
-      r.addRedirect(res.locals.appUrl(`briefing?campaign_id=${campaign.id}&caller_number=${caller.phone_number}&start=1&callback=0&authenticated=${query.authenticated ? '1' : '0'}&assessment=1`))
+      r.addRedirect(res.locals.plivoCallbackUrl(`briefing?campaign_id=${campaign.id}&caller_number=${caller.phone_number}&start=1&callback=0&authenticated=${query.authenticated ? '1' : '0'}&assessment=1`))
     }
     return res.send(r.toXML())
   }
@@ -65,17 +65,17 @@ app.post('/survey_result_assessment', async ({query, body}, res) => {
   const all_possible_responses_entered = current_survey_results.length >= Object.keys(answers).length
 
   if (query.q != 'disposition' && question.multiple && !all_possible_responses_entered) {
-    r.addRedirect(res.locals.appUrl(`survey_multiple_assessment?q=${query.q}&caller_id=${query.caller_id}&campaign_id=${query.campaign_id}&assessment_responses=${current_survey_results_string}`))
+    r.addRedirect(res.locals.plivoCallbackUrl(`survey_multiple_assessment?q=${query.q}&caller_id=${query.caller_id}&campaign_id=${query.campaign_id}&assessment_responses=${current_survey_results_string}`))
     return res.send(r.toXML())
   } else if (query.q != 'disposition' && question.multiple && all_possible_responses_entered) {
     r.addSpeakI18n('survey_multiple_all_possible_entered', {question: question.name})
   }
 
   if (next) {
-    r.addRedirect(res.locals.appUrl(`survey_assessment?q=${next}&caller_id=${query.caller_id}&campaign_id=${query.campaign_id}&assessment=1`))
+    r.addRedirect(res.locals.plivoCallbackUrl(`survey_assessment?q=${next}&caller_id=${query.caller_id}&campaign_id=${query.campaign_id}&assessment=1`))
   } else {
     r.addSpeakI18n('end_assessment_survey')
-    r.addRedirect(res.locals.appUrl(`briefing?campaign_id=${campaign.id}&caller_number=${caller.phone_number}&start=1&callback=0&authenticated=${query.authenticated ? '1' : '0'}&assessment=1`))
+    r.addRedirect(res.locals.plivoCallbackUrl(`briefing?campaign_id=${campaign.id}&caller_number=${caller.phone_number}&start=1&callback=0&authenticated=${query.authenticated ? '1' : '0'}&assessment=1`))
   }
   res.send(r.toXML())
 })
@@ -94,7 +94,7 @@ app.post('/survey_multiple_assessment', async ({query}, res) => {
   _.remove(validDigits, (digit) => _.includes(matched_previous_response_keys, digit))
   if (current_survey_results) { validDigits.push('*') }
   const surveyResponse = r.addGetDigits({
-    action: res.locals.appUrl(`survey_result_assessment?q=${question}&caller_id=${query.caller_id}&campaign_id=${query.campaign_id}&multiple=1&assessment_responses=${current_survey_results_string}`),
+    action: res.locals.plivoCallbackUrl(`survey_result_assessment?q=${question}&caller_id=${query.caller_id}&campaign_id=${query.campaign_id}&multiple=1&assessment_responses=${current_survey_results_string}`),
     redirect: true,
     retries: 10,
     numDigits: 1,

--- a/ivr/common.js
+++ b/ivr/common.js
@@ -3,7 +3,7 @@
 const app = require('express')()
 const plivo = require('plivo')
 const bodyParser = require('body-parser')
-const { plivo_signature } = require('../api/plivo')
+const { get_callback_base_url, plivo_signature } = require('../api/plivo')
 const { languageBlock } = require('../utils')
 const voice = require('./voice')
 
@@ -22,8 +22,8 @@ response.addSpeakI18n = function(block, vars) {
 }
 
 app.use((req, res, next) => {
-  const host= process.env.BASE_URL || `${req.protocol}://${req.hostname}`
-  res.locals.appUrl = endpoint => endpoint ? `${host}/${endpoint}` : host
+  const host = get_callback_base_url() || `${req.protocol}://${req.hostname}`
+  res.locals.plivoCallbackUrl = endpoint => endpoint ? `${host}/${endpoint}` : host
   res.set('Content-Type', 'text/xml')
   next()
 })

--- a/ivr/passcode.js
+++ b/ivr/passcode.js
@@ -11,7 +11,7 @@ app.post('/passcode', async ({query, body}, res) => {
     r.addWait({length: 1})
     r.addSpeakI18n('thanks')
     r.addWait({length: 1})
-    r.addRedirect(res.locals.appUrl(`connect?campaign_id=${campaign.id}&authenticated=1`))
+    r.addRedirect(res.locals.plivoCallbackUrl(`connect?campaign_id=${campaign.id}&authenticated=1`))
     return res.send(r.toXML())
   }
 

--- a/ivr/team.js
+++ b/ivr/team.js
@@ -14,14 +14,14 @@ app.post('/team', async ({query, body}, res) => {
     await user.$query().patch({last_joined_at: new Date()})
     await Event.query().insert({name: 'team join existing', campaign_id: query.campaign_id, value: {log_id: query.log_id}})
     r.addSpeakI18n('rejoined_team', {team_name: team.name})
-    r.addRedirect(res.locals.appUrl(`connect?campaign_id=${query.campaign_id}&team=1&assessment=${query.assessment ? '1' : '0'}&number=${query.number}`))
+    r.addRedirect(res.locals.plivoCallbackUrl(`connect?campaign_id=${query.campaign_id}&team=1&assessment=${query.assessment ? '1' : '0'}&number=${query.number}`))
     return res.send(r.toXML())
   }
 
   if (user && body.Digits === '2') {
     await Event.query().insert({name: 'team selection', campaign_id: query.campaign_id, value: {log_id: query.log_id}})
     const code_prompt = r.addGetDigits({
-      action: res.locals.appUrl(`team/join?campaign_id=${query.campaign_id}&user_id=${user.id}&callback=${query.callback ? query.callback : 0}&authenticated=${query.authenticated ? '1' : '0'}&assessment=${query.assessment ? '1' : '0'}&number=${query.number}`),
+      action: res.locals.plivoCallbackUrl(`team/join?campaign_id=${query.campaign_id}&user_id=${user.id}&callback=${query.callback ? query.callback : 0}&authenticated=${query.authenticated ? '1' : '0'}&assessment=${query.assessment ? '1' : '0'}&number=${query.number}`),
       timeout: 10,
       retries: 10,
       numDigits: 4
@@ -33,7 +33,7 @@ app.post('/team', async ({query, body}, res) => {
   await user.$query().patch({last_joined_at: new Date(), updated_at: new Date(), team_id: null})
   await Event.query().insert({name: 'team join opt out', campaign_id: query.campaign_id, value: {log_id: query.log_id}})
   r.addSpeakI18n('no_team')
-  r.addRedirect(res.locals.appUrl(`connect?campaign_id=${query.campaign_id}&team=1&assessment=${query.assessment ? '1' : '0'}&number=${query.number}`))
+  r.addRedirect(res.locals.plivoCallbackUrl(`connect?campaign_id=${query.campaign_id}&team=1&assessment=${query.assessment ? '1' : '0'}&number=${query.number}`))
   res.send(r.toXML())
 })
 
@@ -47,14 +47,14 @@ app.post('/team/join', async ({query, body}, res) => {
     r.addWait({length: 1})
     r.addSpeakI18n('joined_team', {team_name: team.name})
     r.addWait({length: 1})
-    r.addRedirect(res.locals.appUrl(`connect?campaign_id=${query.campaign_id}&callback=${query.callback ? query.callback : 0}&authenticated=${query.authenticated ? '1' : '0'}&team=1&assessment=${query.assessment ? '1' : '0'}&number=${query.number}`))
+    r.addRedirect(res.locals.plivoCallbackUrl(`connect?campaign_id=${query.campaign_id}&callback=${query.callback ? query.callback : 0}&authenticated=${query.authenticated ? '1' : '0'}&team=1&assessment=${query.assessment ? '1' : '0'}&number=${query.number}`))
     return res.send(r.toXML())
   }
   await Event.query().insert({name: 'team join incorrect passcode', campaign_id: query.campaign_id, value: {log_id: query.log_id}})
   r.addWait({length: 1})
   r.addSpeakI18n('incorrect_passcode')
   r.addWait({length: 1})
-  r.addRedirect(res.locals.appUrl(`connect?campaign_id=${query.campaign_id}&assessment=${query.assessment ? '1' : '0'}&number=${query.number}`))
+  r.addRedirect(res.locals.plivoCallbackUrl(`connect?campaign_id=${query.campaign_id}&assessment=${query.assessment ? '1' : '0'}&number=${query.number}`))
   res.send(r.toXML())
 })
 

--- a/load/index.js
+++ b/load/index.js
@@ -1,3 +1,5 @@
+const { get_callback_base_url } = require('../api/plivo')
+
 const port = process.env.PORT || 4080
 const express = require('express')
 const plivo = require('plivo')
@@ -46,8 +48,8 @@ app.use((req, res, next) => {
   next()
 })
 
-const host = process.env.BASE_URL
-const appUrl = endpoint => endpoint ? `${host}/${endpoint}` : host
+const callback_url = get_callback_base_url()
+const plivoCallbackUrl = endpoint => endpoint ? `${callback_url}/${endpoint}` : callback_url
 
 app.get('/', (req, res) => res.send('<_-.-_>let\'s test.</_-.-_>'))
 
@@ -58,7 +60,7 @@ app.all('/answer', async (req, res) => {
   r.addWait({length: 10})
   r.addDTMF(1)
   r.addWait({length: 15})
-  r.addRedirect(appUrl(`cycle?agent=${req.query.agent}`))
+  r.addRedirect(plivoCallbackUrl(`cycle?agent=${req.query.agent}`))
   return res.send(r.toXML())
 })
 app.all('/hangup', async (req, res) => {
@@ -92,7 +94,7 @@ app.all('/cycle', async (req, res) => {
   }
   state[req.query.agent] = caller.status
   r.addWait({length: (15 + _.random(4))})
-  r.addRedirect(appUrl(`cycle?agent=${req.query.agent}`))
+  r.addRedirect(plivoCallbackUrl(`cycle?agent=${req.query.agent}`))
   return res.send(r.toXML())
 })
 
@@ -124,8 +126,8 @@ const addAgent = async (count) => {
     const params = {
       to: selectTarget(),
       from : agent,
-      answer_url : appUrl(`answer?agent=${agent}`),
-      hangup_url : appUrl(`hangup?agent=${agent}`),
+      answer_url : plivoCallbackUrl(`answer?agent=${agent}`),
+      hangup_url : plivoCallbackUrl(`hangup?agent=${agent}`),
       time_limit: 60 * 120
     }
     try{

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,5 +1,6 @@
 const expect = require('expect.js')
 const nock = require('nock')
+const { set_callback_base_url } = require('../api/plivo')
 const { plivo_setup_campaigns } = require('../campaigns/plivo_setup')
 const { dropFixtures } = require('./test_helper')
 const { Campaign } = require('../models')
@@ -17,6 +18,8 @@ process.env.COUNTRY_CODE = '61'
 process.env.PLIVO_OUTGOING_HANGUP_APP_ID = '123123'
 
 const numberSetupCampaign = Object.assign({}, defaultCampaign, {plivo_setup_status: 'needed', plivo_setup_outgoing_status: 'needed', user_set_outgoing_number: true})
+
+set_callback_base_url('https://test')
 
 describe('plivo_setup_campaigns', () => {
   let searchRentedNumbersCall, createApplicationCall, editRentedNumberCall

--- a/workers/dialer_worker.js
+++ b/workers/dialer_worker.js
@@ -2,8 +2,6 @@
 const { dial, notifyAgents } = require('../dialer')
 const { sleep, error_exit } = require('../utils')
 const { Campaign } = require('../models')
-const host = process.env.BASE_URL
-if (!host) throw `BASE_URL must be set`
 const period = process.env.DIALER_PERIOD || 1000
 
 const work = async () => {
@@ -18,7 +16,7 @@ const work = async () => {
         // these callees will subsequently be dropped
         if (campaign.isPausing()) await campaign.$query().patch({status: 'paused'})
       } else {
-        await dial(host, campaign)
+        await dial(campaign)
       }
     }
     await sleep(period)


### PR DESCRIPTION
Test calls placed via dispatch currently aren't working with GU's current setup, which has an API app separate from the main calling app. The API app is making API calls directly to Plivo, but the callback URLs used are for the API app, not the calling app, and hence the test call gets dropped.

This fixes the issue by reworking how the callback Plivo URLs are generated, making it explicit what the URLs are for, and providing an explicit override to set the callback URL when it is different from the app's base URL.

Fixes #60 